### PR TITLE
check if $ignore and $ignoreTemplate are set

### DIFF
--- a/templates/xmlsitemap.php
+++ b/templates/xmlsitemap.php
@@ -32,8 +32,8 @@ echo '<?xml version="1.0" encoding="utf-8"?>';
 
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <?php foreach($pages->index() as $p):
-  if(in_array($p->uri(), $ignore)) continue;
-  if(in_array($p->intendedTemplate(), $ignoreTemplate) ) continue;
+  if($ignore !== null && in_array($p->uri(), $ignore)) continue;
+  if($ignoreTemplate !== null && in_array($p->intendedTemplate(), $ignoreTemplate) ) continue;
 ?>
   <url>
     <loc><?php echo html($p->url()) ?></loc>

--- a/templates/xmlsitemap.php
+++ b/templates/xmlsitemap.php
@@ -34,6 +34,7 @@ echo '<?xml version="1.0" encoding="utf-8"?>';
 <?php foreach($pages->index() as $p):
   if($ignore !== null && in_array($p->uri(), $ignore)) continue;
   if($ignoreTemplate !== null && in_array($p->intendedTemplate(), $ignoreTemplate) ) continue;
+  if($p->isInvisible() && $p->isHomePage() === false) continue;
 ?>
   <url>
     <loc><?php echo html($p->url()) ?></loc>


### PR DESCRIPTION
added this check to prevent errors if not set in config and make the plugin a bit more robust.
also now invisible pages (like blog-drafts) won't appear in the sitemap unless the page isn't the frontpage
